### PR TITLE
Markers rotate with map

### DIFF
--- a/demo/src/main/java/com/peterlaurence/mapview/demo/fragments/RotatingMapFragment.kt
+++ b/demo/src/main/java/com/peterlaurence/mapview/demo/fragments/RotatingMapFragment.kt
@@ -10,6 +10,7 @@ import com.peterlaurence.mapview.MapView
 import com.peterlaurence.mapview.MapViewConfiguration
 import com.peterlaurence.mapview.api.addCallout
 import com.peterlaurence.mapview.api.addMarker
+import com.peterlaurence.mapview.api.rotateMarker
 import com.peterlaurence.mapview.api.setMarkerTapListener
 import com.peterlaurence.mapview.core.TileStreamProvider
 import com.peterlaurence.mapview.demo.R
@@ -70,17 +71,23 @@ class RotatingMapFragment : Fragment() {
         mapView.addNewMarker(0.5, 0.5, "marker #1")
         mapView.addNewMarker(0.4, 0.3, "marker #2")
         mapView.addNewMarker(0.6, 0.4, "marker #3")
-
+        mapView.addCurrentPositionMarker(0.7, 0.7, 0f)
 
         /* When a marker is tapped, we want to show a callout view */
         mapView.setMarkerTapListener(object : MarkerTapListener {
             override fun onMarkerTap(view: View, x: Int, y: Int) {
                 if (view is MapMarker) {
-                    val callout = MarkerCallout(context)
-                    callout.setTitle(view.name)
-                    callout.setSubTitle("position: ${view.x} , ${view.y}")
-                    mapView.addCallout(callout, view.x, view.y, -0.5f, -1.2f, 0f, 0f)
-                    callout.transitionIn()
+                    if (view.name == POSITION_MARKER) {
+                        val randomAngle = (0..360).random().toFloat()
+                        mapView.rotateMarker(view, randomAngle)
+                    }
+                    else {
+                        val callout = MarkerCallout(context)
+                        callout.setTitle(view.name)
+                        callout.setSubTitle("position: ${view.x} , ${view.y}")
+                        mapView.addCallout(callout, view.x, view.y, -0.5f, -1.2f, 0f, 0f)
+                        callout.transitionIn()
+                    }
                 }
             }
         })
@@ -128,4 +135,14 @@ class RotatingMapFragment : Fragment() {
 
         addMarker(marker, x, y)
     }
+
+    private fun MapView.addCurrentPositionMarker(x: Double, y: Double, fixedAngle: Float) {
+        val marker = MapMarker(context, x, y, POSITION_MARKER).apply {
+            setImageResource(R.drawable.position_marker)
+        }
+
+        addMarker(marker, x, y, -0.5f, -0.5f, fixedAngle = fixedAngle)
+    }
 }
+
+const val POSITION_MARKER = "position marker"

--- a/demo/src/main/res/drawable/position_marker.xml
+++ b/demo/src/main/res/drawable/position_marker.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#235F85"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,2L4.5,20.29l0.71,0.71L12,18l6.79,3 0.71,-0.71z"/>
+</vector>

--- a/mapview/src/main/java/com/peterlaurence/mapview/api/MarkerApi.kt
+++ b/mapview/src/main/java/com/peterlaurence/mapview/api/MarkerApi.kt
@@ -16,16 +16,19 @@ import com.peterlaurence.mapview.markers.MarkerTapListener
  * @param relativeAnchorTop  The y-axis position of a marker will be offset by a number equal to the height of the marker multiplied by this value.
  * @param absoluteAnchorLeft The x-axis position of a marker will be offset by this value.
  * @param absoluteAnchorTop  The y-axis position of a marker will be offset by this value.
+ * @param fixedAngle Angle which should the marker face (depends on map angle).
+ *                   If the angle is null the marker will not rotate.
  */
 fun MapView.addMarker(view: View, x: Double, y: Double, relativeAnchorLeft: Float = -0.5f,
                       relativeAnchorTop: Float = -1f, absoluteAnchorLeft: Float = 0f,
-                      absoluteAnchorTop: Float = 0f) {
+                      absoluteAnchorTop: Float = 0f, fixedAngle: Float? = null) {
 
     markerLayout.addMarker(view,
             coordinateTranslater.translateX(x),
             coordinateTranslater.translateY(y),
             relativeAnchorLeft, relativeAnchorTop,
-            absoluteAnchorLeft, absoluteAnchorTop
+            absoluteAnchorLeft, absoluteAnchorTop,
+            fixedAngle
     )
 }
 
@@ -42,14 +45,27 @@ fun MapView.setMarkerTapListener(markerTapListener: MarkerTapListener) {
 /**
  * Moves an existing marker to another position.
  *
- * @param view The marker View to be repositioned.
- * @param x    Relative x position the View instance should be positioned at.
- * @param y    Relative y position the View instance should be positioned at.
+ * @param view  The marker View to be repositioned.
+ * @param x     Relative x position the View instance should be positioned at.
+ * @param y     Relative y position the View instance should be positioned at.
+ * @param angle Angle by which should the marker be rotated (depends on map angle).
+ *              If the angle is null the marker will not rotate.
  */
-fun MapView.moveMarker(view: View, x: Double, y: Double) {
+fun MapView.moveMarker(view: View, x: Double, y: Double, angle: Float? = null) {
     markerLayout.moveMarker(view,
             coordinateTranslater.translateX(x),
-            coordinateTranslater.translateY(y))
+            coordinateTranslater.translateY(y),
+            angle)
+}
+
+/**
+ * Rotates an existing marker.
+ *
+ * @param view  The marker View to be repositioned.
+ * @param angle Angle by which should the marker be rotated (depends on map angle).
+ */
+fun MapView.rotateMarker(view: View, angle: Float) {
+    markerLayout.rotateMarker(view, angle)
 }
 
 /**

--- a/mapview/src/main/java/com/peterlaurence/mapview/api/MarkerApi.kt
+++ b/mapview/src/main/java/com/peterlaurence/mapview/api/MarkerApi.kt
@@ -16,7 +16,7 @@ import com.peterlaurence.mapview.markers.MarkerTapListener
  * @param relativeAnchorTop  The y-axis position of a marker will be offset by a number equal to the height of the marker multiplied by this value.
  * @param absoluteAnchorLeft The x-axis position of a marker will be offset by this value.
  * @param absoluteAnchorTop  The y-axis position of a marker will be offset by this value.
- * @param fixedAngle Angle which should the marker face (depends on map angle).
+ * @param fixedAngle Angle which the marker should face (depends on map angle).
  *                   If the angle is null the marker will not rotate.
  */
 fun MapView.addMarker(view: View, x: Double, y: Double, relativeAnchorLeft: Float = -0.5f,
@@ -48,7 +48,7 @@ fun MapView.setMarkerTapListener(markerTapListener: MarkerTapListener) {
  * @param view  The marker View to be repositioned.
  * @param x     Relative x position the View instance should be positioned at.
  * @param y     Relative y position the View instance should be positioned at.
- * @param angle Angle by which should the marker be rotated (depends on map angle).
+ * @param angle Angle by which the marker should be rotated (depends on map angle).
  *              If the angle is null the marker will not rotate.
  */
 fun MapView.moveMarker(view: View, x: Double, y: Double, angle: Float? = null) {
@@ -62,7 +62,7 @@ fun MapView.moveMarker(view: View, x: Double, y: Double, angle: Float? = null) {
  * Rotates an existing marker.
  *
  * @param view  The marker View to be repositioned.
- * @param angle Angle by which should the marker be rotated (depends on map angle).
+ * @param angle Angle by which the marker should be rotated (depends on map angle).
  */
 fun MapView.rotateMarker(view: View, angle: Float) {
     markerLayout.rotateMarker(view, angle)

--- a/mapview/src/main/java/com/peterlaurence/mapview/markers/MarkerLayout.kt
+++ b/mapview/src/main/java/com/peterlaurence/mapview/markers/MarkerLayout.kt
@@ -74,9 +74,9 @@ open class MarkerLayout(context: Context) : ViewGroup(context), ReferentialOwner
                 layoutParams.right = layoutParams.left + actualWidth
                 layoutParams.bottom = layoutParams.top + actualHeight
 
-                if (layoutParams.shouldRotateWithMap) {
-                    // rotates Marker with map by current map degrees or keeps fixedAngle
-                    child.rotation = layoutParams.fixedAngle?.plus(referentialData.angle) ?: referentialData.angle
+                if (layoutParams.fixedAngle != null) {
+                    // rotates marker with map or keeps fixed angle
+                    child.rotation = layoutParams.fixedAngle!!.plus(referentialData.angle)
                 }
             } else {
                 // save computed values
@@ -84,6 +84,8 @@ open class MarkerLayout(context: Context) : ViewGroup(context), ReferentialOwner
                 layoutParams.top = (scaledY + heightOffset).toInt()
                 layoutParams.right = layoutParams.left + actualWidth
                 layoutParams.bottom = layoutParams.top + actualHeight
+
+                child.rotation = layoutParams.fixedAngle ?: 0f
             }
         }
         return layoutParams
@@ -184,17 +186,15 @@ open class MarkerLayout(context: Context) : ViewGroup(context), ReferentialOwner
 }
 
 internal class MarkerLayoutParams(width: Int, height: Int, var x: Int, var y: Int,
-                                  var relativeAnchorX: Float, var relativeAnchorY: Float,
-                                  var absoluteAnchorX: Float, var absoluteAnchorY: Float,
-                                  var fixedAngle: Float? = null)
-                                  : ViewGroup.LayoutParams(width, height) {
+                                 var relativeAnchorX: Float, var relativeAnchorY: Float,
+                                 var absoluteAnchorX: Float, var absoluteAnchorY: Float,
+                                 var fixedAngle: Float? = null)
+                                 : ViewGroup.LayoutParams(width, height) {
 
     var top: Int = 0
     var left: Int = 0
     var bottom: Int = 0
     var right: Int = 0
-
-    var shouldRotateWithMap: Boolean = fixedAngle != null
 
     fun getHitRect(): Rect = Rect(left, top, right, bottom)
 }


### PR DESCRIPTION
Hey, I needed to rotate markers with the angle of the map, so I added functionality for the marker to stick to specified angle. This works nicely with displaying current position in custom map, in this case the angle of the map is determined by bearing. See updated demo.

Rotation of the marker is done optionally in `addMarker`, `moveMarker` (to optimize updating current position) and manually in `rotateMarker`  function.

