### PR TITLE
Added redrawTiles function

### DIFF
--- a/mapview/src/main/java/com/peterlaurence/mapview/MapView.kt
+++ b/mapview/src/main/java/com/peterlaurence/mapview/MapView.kt
@@ -173,6 +173,10 @@ open class MapView @JvmOverloads constructor(context: Context, attrs: AttributeS
         job.cancel()
     }
 
+    fun redrawTiles() {
+        renderVisibleTilesThrottled();
+    }
+
     private fun initChildViews(visibleTilesResolver: VisibleTilesResolver) {
         /* Remove the TileCanvasView if it was already added */
         if (this::tileCanvasView.isInitialized) {


### PR DESCRIPTION
In case when you asynchronously generate image tile map, after the generation is done, you need to move the finger over the map to trigger redrawing of the tiles. To fix this I needed to add a function allowing me to manually call the redraw.