### PR TITLE
Added alphaTick to TileOptionsProvider

### DIFF
--- a/mapview/src/main/java/com/peterlaurence/mapview/core/TileOptionsProvider.kt
+++ b/mapview/src/main/java/com/peterlaurence/mapview/core/TileOptionsProvider.kt
@@ -10,4 +10,12 @@ interface TileOptionsProvider {
     /* Must not be a blocking call - should return immediately */
     @JvmDefault
     fun getColorFilter(row: Int, col: Int, zoomLvl: Int): ColorFilter? = null
+
+    /**
+     * Controls the speed of fade in effect when rendering tiles. Higher values make alpha
+     * value go to 255 faster. Should be in between (0.0f, 1.0f].
+     */
+    @JvmDefault
+    val alphaTick : Float
+        get() = 0.07f
 }

--- a/mapview/src/main/java/com/peterlaurence/mapview/view/TileCanvasView.kt
+++ b/mapview/src/main/java/com/peterlaurence/mapview/view/TileCanvasView.kt
@@ -25,7 +25,7 @@ internal class TileCanvasView(ctx: Context, viewModel: TileCanvasViewModel,
             field = value
             invalidate()
         }
-    private val alphaTick = 0.07f
+    private val alphaTick = viewModel.getAlphaTick()
 
     private var tilesToRender = listOf<Tile>()
     private val dest = Rect()

--- a/mapview/src/main/java/com/peterlaurence/mapview/viewmodel/TileCanvasViewModel.kt
+++ b/mapview/src/main/java/com/peterlaurence/mapview/viewmodel/TileCanvasViewModel.kt
@@ -80,6 +80,10 @@ internal class TileCanvasViewModel(private val scope: CoroutineScope, tileSize: 
         return tilesToRenderLiveData
     }
 
+    fun getAlphaTick() : Float {
+        return tileOptionsProvider?.alphaTick ?: 0.07f
+    }
+
     fun setViewport(viewport: Viewport) {
         /* It's important to set the idle flag to false before launching computations, so that
          * tile eviction don't happen too quickly (can cause blinks) */


### PR DESCRIPTION
Hello!
I needed to disable fade in effect in some cases so I added an option to specify alphaTick. It's optional and has default value of 0.07 as before.