### PR TITLE
Fixed redrawTiles not working

### DIFF
--- a/mapview/src/main/java/ovh/plrapps/mapview/core/TileCollector.kt
+++ b/mapview/src/main/java/ovh/plrapps/mapview/core/TileCollector.kt
@@ -104,13 +104,16 @@ class TileCollector(private val workerCount: Int, private val bitmapConfig: Bitm
                         BitmapFactory.decodeStream(retry, null, null)
                     }
                 } else null
-            }.getOrNull() ?: continue
+            }.getOrNull()
+            tilesDownloaded.send(spec)
+            if (bitmap == null) {
+                continue
+            }
 
             val tile = Tile(spec.zoom, spec.row, spec.col, spec.subSample).apply {
                 this.bitmap = bitmap
             }
             tilesOutput.send(tile)
-            tilesDownloaded.send(spec)
         }
     }
 


### PR DESCRIPTION
Hello

Since the commit [ee06fba22a9fe4f6c2a67a095fdb1ed9d70938f8](https://github.com/p-lr/MapView/commit/ee06fba22a9fe4f6c2a67a095fdb1ed9d70938f8) function `redrawTiles` stopped working.

I managed to find the reason for this. In the old code in the function `CoroutineScope.worker` instruction `tilesDownloaded.send(spec)` was always called, regardless of the bitmap being succesfully loaded or not. It was placed inside `finally` block, so whether we got `null` bitmap and called `continue`, or we got an exception it was called for every tile.

In the current implementation it is only called when we get the bitmap correctly. Current behaviour causes `redrawTiles` to not work (at least for me). I adjusted the code accordingly, to bring back the old behaviour, while leaving the new load algorithm intact and it seems to have solved the issue.

I don't know exactly what those channels are doing, I just found an issue and a possible fix for it. If you have a better solution than this one, then feel free to do it your own way.

Best regards
